### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "images"
   ],
   "description": "Converts Supervisely to MOT format and prepares tar archive for download",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
   ],
   "description": "Converts Supervisely to MOT format and prepares tar archive for download",
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "instance_version": "6.4.57",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "images"
   ],
   "description": "Converts Supervisely to MOT format and prepares tar archive for download",
-  "docker_image": "supervisely/base-py-sdk:6.35.0",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.4.57",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,1 @@
+supervisely==6.73.564

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.35.0
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
